### PR TITLE
Include META.json in releases, and updated format of Changes to facilitate tool processing

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl extension Lingua::EN::VerbTense
     - Corrected name in header of Changes file
     - Updated format of Changes to follow CPAN::Changes::Spec,
       fixing one incorrect version number in the process
+    - Added [MetaJSON] to dist.ini, so releases will include META.json
 
 3.003 2012-08-13 JJNAPIORK
     - Fixed changes file

--- a/Changes
+++ b/Changes
@@ -2,15 +2,17 @@ Revision history for Perl extension Lingua::EN::VerbTense
 
 3.004 2017-11-?? JJNAPIORK
     - Corrected name in header of Changes file
+    - Updated format of Changes to follow CPAN::Changes::Spec,
+      fixing one incorrect version number in the process
 
-3.003 Mon Aug 13 16.17:00 2012
+3.003 2012-08-13 JJNAPIORK
     - Fixed changes file
     - be sure everything is unix format
 
-3.002 Thu Aug 09 15:39:00 2012
+3.002 2012-08-09 JJNAPIORK
     - fixed borked dist
 
-3.01  Thu Aug 09 15:39:00 2012
+3.001 2012-08-09 JJNAPIORK
     - New maintainer.
     - Modernized the package and distribution layout to follow
       contemporary standards
@@ -19,6 +21,6 @@ Revision history for Perl extension Lingua::EN::VerbTense
     - Created a git repository
     - converted to Dist::Zilla for distribution lifecycle
 
-3.00  Thu Sep 28 21:12:30 2000
+3.00 2000-09-28 JBRYAN
 	- original CPAN version; created by Josiah Bryan
 

--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
-Revision history for Perl extension Lingua::EN::ParseVerb
+Revision history for Perl extension Lingua::EN::VerbTense
+
+3.004 2017-11-?? JJNAPIORK
+    - Corrected name in header of Changes file
 
 3.003 Mon Aug 13 16.17:00 2012
     - Fixed changes file

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Perl_5
 copyright_holder = Chris Meyer
 copyright_year = 2000
 abstract = Parses verb structures into modal, tense, & infinitive.
-version = 3.003
+version = 3.004
 
 [@Basic]
 

--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,7 @@ abstract = Parses verb structures into modal, tense, & infinitive.
 version = 3.004
 
 [@Basic]
+[MetaJSON]
 
 [MetaResources]
 homepage = https://github.com/jjn1056/Lingua-EN-VerbTense


### PR DESCRIPTION
Hi John,

This was originally going to be just adding [MetaJSON], so that the next release will have a `META.json` file. The json version of the metadata gives better fidelity of dependency information, which is good for tools, and calculating river position more accurately.

I've also tweaked the the Changes file:

 * Had the wrong dist name
 * One release's version number had a missing 0 (pretty minor, I know :-)
 * Updated to follow the format in CPAN::Changes::Spec, which facilitates automatic processing

Cheers,
Neil